### PR TITLE
Update @com_google_protobuf//:proto_api dependency for Protobuf v22.0 and newer.

### DIFF
--- a/pybind11_protobuf/BUILD
+++ b/pybind11_protobuf/BUILD
@@ -61,7 +61,7 @@ pybind_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
-        "@com_google_protobuf//:proto_api",
+        "@com_google_protobuf//python:proto_api",
         "@com_google_protobuf//:protobuf",
     ],
 )


### PR DESCRIPTION
The target `@com_google_protobuf//:proto_api` moved to `@com_google_protobuf//python:proto_api` with Protobuf v22.0 (Feb 16, 2023).

If needed, both versions can be supported by conditioning on PROTO_VERSION. Let me know if you'd prefer to do that.