### PR TITLE
Fix using system dependencies with CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,16 +27,19 @@ find_package(Python COMPONENTS Interpreter Development)
 # Build dependencies
 
 set(_absl_repository "https://github.com/abseil/abseil-cpp.git")
-set(_absl_version 20220623.1)
-set(_absl_tag 20220623.1)
+set(_absl_version 20230125)
+set(_absl_tag 20230125.3)
+find_package(absl ${_absl_version} QUIET)
 
 set(_protobuf_repository "https://github.com/protocolbuffers/protobuf.git")
-set(_protobuf_version 21.5)
-set(_protobuf_tag v21.5)
+set(_protobuf_version 3.23.3)
+set(_protobuf_tag v23.3)
+find_package(Protobuf ${_protobuf_version} QUIET)
 
 set(_pybind11_repository "https://github.com/pybind/pybind11.git")
-set(_pybind11_version 2.10)
-set(_pybind11_tag v2.10.1)
+set(_pybind11_version 2.11.1)
+set(_pybind11_tag v2.11.1)
+find_package(pybind11 ${_pybind11_version} QUIET)
 
 add_subdirectory(cmake/dependencies dependencies)
 

--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -3,9 +3,9 @@ include(FetchContent)
 # ============================================================================
 # Declare all dependencies first
 
-find_package(absl ${_absl_version} EXACT QUIET)
 if(NOT absl_FOUND)
   set(ABSL_PROPAGATE_CXX_STD ON)
+  set(ABSL_ENABLE_INSTALL ON)
   FetchContent_Declare(
     absl
     GIT_REPOSITORY ${_absl_repository}
@@ -15,7 +15,6 @@ endif()
 # https://stackoverflow.com/questions/63309544/cmake-protobuf-external-to-application-code
 # https://cmake.org/cmake/help/latest/policy/CMP0077.html
 # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7565/diffs
-find_package(Protobuf ${_protobuf_version} EXACT QUIET)
 if(NOT Protobuf_FOUND)
   set(protobuf_BUILD_TESTS
       OFF
@@ -27,7 +26,6 @@ if(NOT Protobuf_FOUND)
     GIT_SUBMODULES "")
 endif()
 
-find_package(pybind11 ${_pybind11_version} EXACT QUIET)
 if(NOT pybind11_FOUND)
   set(PYBIND11_TEST OFF)
   FetchContent_Declare(


### PR DESCRIPTION
The CMake build system attempted to support using system dependencies, but this functionality did not work for two reasons:
  * `find_package()` was called in a subdirectory, which means that imported targets were not visible in the top-level build.
  * The version numbers for abseil and Protobuf didn't match the format used by their CMake modules, making `find_package()` always fail.

I also synchronized the version numbers with those used in the Bazel build and removed the exact version constraints. In my opinion, the most common use of system dependencies is probably by distro packagers. In this case we can't guarantee an exactly matching patch version and would most likely have to patch out the exact version check anyway. If you don't agree with this, I'm fine with reverting that part.