### PR TITLE
Make pyproto api optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # Options
 
 option(BUILD_TESTS "Build tests." OFF)
+option(ENABLE_PYPROTO_API "Enable usage of proto_api." OFF)
 
 # ============================================================================
 # Find Python
@@ -68,10 +69,18 @@ add_library(
   # bazel: pybind_library: proto_cast_util
   pybind11_protobuf/proto_cast_util.cc
   pybind11_protobuf/proto_cast_util.h
-  pybind11_protobuf/proto_caster_impl.h
+  pybind11_protobuf/proto_caster_impl.h)
+
+target_sources(
   # bazel: cc_library::check_unknown_fields
-  pybind11_protobuf/check_unknown_fields.cc
-  pybind11_protobuf/check_unknown_fields.h)
+  pybind11_native_proto_caster #
+  PRIVATE pybind11_protobuf/check_unknown_fields.cc
+          pybind11_protobuf/check_unknown_fields.h)
+
+if(ENABLE_PYPROTO_API)
+  target_compile_definitions(pybind11_native_proto_caster
+                             PRIVATE PYBIND11_PROTOBUF_ENABLE_PYPROTO_API)
+endif()
 
 target_link_libraries(
   pybind11_native_proto_caster
@@ -98,10 +107,18 @@ add_library(
   # bazel: pybind_library: proto_cast_util
   pybind11_protobuf/proto_cast_util.cc
   pybind11_protobuf/proto_cast_util.h
-  pybind11_protobuf/proto_caster_impl.h
-  # bazel: cc_library: check_unknown_fields
-  pybind11_protobuf/check_unknown_fields.cc
-  pybind11_protobuf/check_unknown_fields.h)
+  pybind11_protobuf/proto_caster_impl.h)
+
+target_sources(
+  # bazel: cc_library::check_unknown_fields
+  pybind11_wrapped_proto_caster
+  PRIVATE pybind11_protobuf/check_unknown_fields.cc
+          pybind11_protobuf/check_unknown_fields.h)
+
+if(ENABLE_PYPROTO_API)
+  target_compile_definitions(pybind11_wrapped_proto_caster
+                             PRIVATE PYBIND11_PROTOBUF_ENABLE_PYPROTO_API)
+endif()
 
 target_link_libraries(
   pybind11_wrapped_proto_caster
@@ -118,9 +135,6 @@ target_include_directories(
   pybind11_wrapped_proto_caster
   PRIVATE ${PROJECT_SOURCE_DIR} ${protobuf_INCLUDE_DIRS} ${protobuf_SOURCE_DIR}
           ${pybind11_INCLUDE_DIRS})
-
-# TODO set defines PYBIND11_PROTOBUF_ENABLE_PYPROTO_API see: bazel:
-# pybind_library: proto_cast_util
 
 # bazel equivs. checklist
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ target_include_directories(
 # ============================================================================
 # pybind11_native_proto_caster shared library
 add_library(
-  pybind11_native_proto_caster SHARED
+  pybind11_native_proto_caster STATIC
   # bazel: pybind_library: native_proto_caster
   pybind11_protobuf/native_proto_caster.h
   # bazel: pybind_library: enum_type_caster
@@ -101,7 +101,7 @@ target_include_directories(
 # ============================================================================
 # pybind11_wrapped_proto_caster shared library
 add_library(
-  pybind11_wrapped_proto_caster SHARED
+  pybind11_wrapped_proto_caster STATIC
   # bazel: pybind_library: wrapped_proto_caster
   pybind11_protobuf/wrapped_proto_caster.h
   # bazel: pybind_library: proto_cast_util

--- a/pybind11_protobuf/check_unknown_fields.cc
+++ b/pybind11_protobuf/check_unknown_fields.cc
@@ -34,6 +34,7 @@ std::string MakeAllowListKey(
   return absl::StrCat(top_message_descriptor_full_name, ":",
                       unknown_field_parent_message_fqn);
 }
+#if defined(PYBIND11_PROTOBUF_ENABLE_PYPROTO_API)
 
 /// Recurses through the message Descriptor class looking for valid extensions.
 /// Stores the result to `memoized`.
@@ -173,6 +174,7 @@ std::string HasUnknownFields::BuildErrorMessage() const {
   return emsg;
 }
 
+#endif
 }  // namespace
 
 void AllowUnknownFieldsFor(absl::string_view top_message_descriptor_full_name,
@@ -181,6 +183,7 @@ void AllowUnknownFieldsFor(absl::string_view top_message_descriptor_full_name,
                                           unknown_field_parent_message_fqn));
 }
 
+#if defined(PYBIND11_PROTOBUF_ENABLE_PYPROTO_API)
 std::optional<std::string> CheckRecursively(
     const ::google::protobuf::python::PyProto_API* py_proto_api,
     const ::google::protobuf::Message* message) {
@@ -195,5 +198,6 @@ std::optional<std::string> CheckRecursively(
   }
   return search.BuildErrorMessage();
 }
+#endif
 
 }  // namespace pybind11_protobuf::check_unknown_fields

--- a/pybind11_protobuf/check_unknown_fields.h
+++ b/pybind11_protobuf/check_unknown_fields.h
@@ -3,9 +3,12 @@
 
 #include <optional>
 
-#include "google/protobuf/message.h"
-#include "python/google/protobuf/proto_api.h"
 #include "absl/strings/string_view.h"
+#include "google/protobuf/message.h"
+
+#if defined(PYBIND11_PROTOBUF_ENABLE_PYPROTO_API)
+#include "python/google/protobuf/proto_api.h"
+#endif // PYBIND11_PROTOBUF_ENABLE_PYPROTO_API
 
 namespace pybind11_protobuf::check_unknown_fields {
 
@@ -45,9 +48,11 @@ class ExtensionsWithUnknownFieldsPolicy {
 void AllowUnknownFieldsFor(absl::string_view top_message_descriptor_full_name,
                            absl::string_view unknown_field_parent_message_fqn);
 
+#if defined(PYBIND11_PROTOBUF_ENABLE_PYPROTO_API)
 std::optional<std::string> CheckRecursively(
     const ::google::protobuf::python::PyProto_API* py_proto_api,
     const ::google::protobuf::Message* top_message);
+#endif // PYBIND11_PROTOBUF_ENABLE_PYPROTO_API
 
 }  // namespace pybind11_protobuf::check_unknown_fields
 


### PR DESCRIPTION
For CMake builds (at least), `PYBIND11_PROTOBUF_ENABLE_PYPROTO_API` was never defined, so the proto_api was not used in most cases.

Though, there are some parts of the code which did depend on the (considered private/obsolete) protobuf proto_api.h header file. Make sure all uses are behind the `PYBIND11_PROTOBUF_ENABLE_PYPROTO_API` guards.

This was tested with google-or-tools 9.9, compilation and and unit test pass.

See #127.