### PR TITLE
fix build against protobuf v34+

### DIFF
--- a/pybind11_protobuf/proto_cast_util.cc
+++ b/pybind11_protobuf/proto_cast_util.cc
@@ -361,7 +361,7 @@ class PythonDescriptorPoolWrapper {
 
     // Find a file by file name.
     bool FindFileByName(
-        const std::string& filename
+        StringViewArg filename
         ,
         FileDescriptorProto* output) override {
       try {
@@ -379,7 +379,7 @@ class PythonDescriptorPoolWrapper {
 
     // Find the file that declares the given fully-qualified symbol name.
     bool FindFileContainingSymbol(
-        const std::string& symbol_name
+        StringViewArg symbol_name
         ,
         FileDescriptorProto* output) override {
       try {
@@ -399,7 +399,7 @@ class PythonDescriptorPoolWrapper {
     // Find the file which defines an extension extending the given message type
     // with the given field number.
     bool FindFileContainingExtension(
-        const std::string& containing_type
+        StringViewArg containing_type
         ,
         int field_number, FileDescriptorProto* output) override {
       try {


### PR DESCRIPTION
Upstream protobuf changed StringViewArg from const std::string& to absl::string_view: https://github.com/protocolbuffers/protobuf/commit/aeb5f2dfac014d1e5d47bbd5dcfbf824cc8c5a24

By using the same StringViewArg alias they use in their declarations, we can fix the build against protobuf v34+ without losing support for older versions.

We get new warnings, because this alias is deprecated, but I think that's better than bumping the required protobuf version unnecessarily. This approach can always be revisited if they fully drop StringViewArg in the future.

Tested against protobuf v32.1 and v34.1.